### PR TITLE
Virtualenv bootstrap, Pex update, Requests lib

### DIFF
--- a/pex/BUILD
+++ b/pex/BUILD
@@ -9,6 +9,7 @@ genrule(
         "@setuptools_src//file",
         "@wheel_src//file",
         "@pex_src//file",
+        "@requests_src//file",
         "@virtualenv_src//file",
     ],
     outs = ["pex_wrapper.pex"],
@@ -38,6 +39,7 @@ genrule(
             --find-links $$OUTDIR \
             --find-links $$(dirname $(location @pex_src//file)) \
             --find-links $$(dirname $(location @setuptools_src//file)) \
+            --find-links $$(dirname $(location @requests_src//file)) \
             --find-links $$(dirname $(location @wheel_src//file))
     """,
     visibility = ["//visibility:public"],

--- a/pex/BUILD
+++ b/pex/BUILD
@@ -6,6 +6,7 @@ genrule(
     srcs = [
         "wrapper/setup.py",
         "wrapper/pex_wrapper.py",
+        "wrapper/README",
         "@setuptools_src//file",
         "@wheel_src//file",
         "@pex_src//file",

--- a/pex/BUILD
+++ b/pex/BUILD
@@ -9,43 +9,31 @@ genrule(
         "@setuptools_src//file",
         "@wheel_src//file",
         "@pex_src//file",
+        "@virtualenv_src//file",
     ],
     outs = ["pex_wrapper.pex"],
     executable = True,
     cmd = """
         OUTDIR=$$(cd $(@D) && pwd)
-        export PYTHONUSERBASE=$$OUTDIR/__pythonuserbase
+        mkdir venv_src
+        tar -C venv_src --strip-components 1 -xzf $(location @virtualenv_src//file)
+        python venv_src/virtualenv.py --no-download --quiet pex_venv
+        _python="$$PWD/pex_venv/bin/python"
 
-        PYTHON_VERSION="$$(python -c "import sys; print sys.version[:3]")"
-        # Create /.../lib/pythonX.Y/site-packages so easy_install doesn't fail
-        # `sed` works around https://github.com/pypa/setuptools/issues/672
-        export PYTHONPATH="$$(python -m site --user-site | \
-            sed "s|lib/python/site-packages|lib/python$$PYTHON_VERSION/site-packages|")/"
-        mkdir -p $$PYTHONPATH
-
-        # Bootstrap setuptools:
-        tar xzf $(location @setuptools_src//file)
-        (cd setuptools* && \
-         python setup.py --quiet install --prefix=$$PYTHONUSERBASE)
-
-        # Use that new setuptools to install wheel and pex:
-        $$PYTHONUSERBASE/bin/easy_install --quiet \
-                                          --build-directory $(@D)/build \
-                                          --prefix=$$PYTHONUSERBASE \
-                                          $(location @wheel_src//file)
-        $$PYTHONUSERBASE/bin/easy_install --quiet \
-                                          --build-directory $(@D)/build \
-                                          --prefix=$$PYTHONUSERBASE \
-                                          $(location @pex_src//file)
+        pex_venv/bin/pip install pex \
+            --quiet \
+            --no-cache-dir --no-index --build $(@D)/build \
+            --find-links $$(dirname $(location @pex_src//file)) \
+            --find-links $$(dirname $(location @setuptools_src//file))
 
         # Work around setuptools insistance on writing to the source directory,
         # which is discouraged by Bazel (and annoying)
         cp -r $$(dirname $(location wrapper/setup.py)) $(@D)/.pex_wrapper
         ( cd $(@D)/.pex_wrapper
-          python setup.py --quiet sdist --dist-dir $$OUTDIR )
+          $$_python setup.py --quiet sdist --dist-dir $$OUTDIR )
 
         # Use the bootstrapped pex to build pex_wrapper.pex
-        $$PYTHONUSERBASE/bin/pex pex_wrapper \
+        pex_venv/bin/pex pex_wrapper \
             --disable-cache --no-index -m pex_wrapper -o $@ \
             --find-links $$OUTDIR \
             --find-links $$(dirname $(location @pex_src//file)) \

--- a/pex/BUILD
+++ b/pex/BUILD
@@ -11,20 +11,17 @@ genrule(
         "@wheel_src//file",
         "@pex_src//file",
         "@requests_src//file",
-        "@virtualenv_src//file",
     ],
+    tools = ["@virtualenv//:virtualenv"],
     outs = ["pex_wrapper.pex"],
     executable = True,
     cmd = """
         OUTDIR=$$(cd $(@D) && pwd)
-        mkdir venv_src
-        tar -C venv_src --strip-components 1 -xzf $(location @virtualenv_src//file)
-        python venv_src/virtualenv.py --no-download --quiet pex_venv
-        _python="$$PWD/pex_venv/bin/python"
+        $(location @virtualenv//:virtualenv) --no-download --quiet venv
+        _python="$$PWD/venv/bin/python"
 
-        pex_venv/bin/pip install pex \
-            --quiet \
-            --no-cache-dir --no-index --build $(@D)/build \
+        venv/bin/pip install pex \
+            --quiet --no-cache-dir --no-index --build $(@D)/pexbuild \
             --find-links $$(dirname $(location @pex_src//file)) \
             --find-links $$(dirname $(location @setuptools_src//file))
 
@@ -35,7 +32,7 @@ genrule(
           $$_python setup.py --quiet sdist --dist-dir $$OUTDIR )
 
         # Use the bootstrapped pex to build pex_wrapper.pex
-        pex_venv/bin/pex pex_wrapper \
+        venv/bin/pex pex_wrapper \
             --disable-cache --no-index -m pex_wrapper -o $@ \
             --find-links $$OUTDIR \
             --find-links $$(dirname $(location @pex_src//file)) \

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -469,6 +469,12 @@ def pex_repositories():
   )
 
   native.http_file(
+      name = "requests_src",
+      url = "https://pypi.python.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz",
+      sha256 = "63f1815788157130cee16a933b2ee184038e975f0017306d723ac326b5525b54",
+  )
+
+  native.http_file(
       name = "virtualenv_src",
       url = "https://pypi.python.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz",
       sha256 = "fab40f32d9ad298fba04a260f3073505a16d52539a84843cf8c8369d4fd17167",

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -467,3 +467,9 @@ def pex_repositories():
       url = "https://pypi.python.org/packages/60/fc/b94f97a1db627710526715fd17fa322189e3c98f16331b3eb5390c585886/pex-1.1.13.tar.gz",
       sha256 = "241cc768d0ad56e53a099d2bc2c0eeb93857fc105cdc3d3da7cb030f4486e8ec",
   )
+
+  native.http_file(
+      name = "virtualenv_src",
+      url = "https://pypi.python.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz",
+      sha256 = "fab40f32d9ad298fba04a260f3073505a16d52539a84843cf8c8369d4fd17167",
+  )

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -464,8 +464,8 @@ def pex_repositories():
 
   native.http_file(
       name = "pex_src",
-      url = "https://pypi.python.org/packages/60/fc/b94f97a1db627710526715fd17fa322189e3c98f16331b3eb5390c585886/pex-1.1.13.tar.gz",
-      sha256 = "241cc768d0ad56e53a099d2bc2c0eeb93857fc105cdc3d3da7cb030f4486e8ec",
+      url = "https://pypi.python.org/packages/6d/b9/aacedca314f7061f84c021c9eaac9ceac9c57f277e4e9bbb6d998facec8d/pex-1.1.14.tar.gz",
+      sha256 = "2d0f5ec39d61c0ef0f806247d7e2702e5354583df7f232db5d9a3b287173e857",
   )
 
   native.http_file(

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -474,8 +474,17 @@ def pex_repositories():
       sha256 = "63f1815788157130cee16a933b2ee184038e975f0017306d723ac326b5525b54",
   )
 
-  native.http_file(
-      name = "virtualenv_src",
+  native.new_http_archive(
+      name = "virtualenv",
       url = "https://pypi.python.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz",
       sha256 = "fab40f32d9ad298fba04a260f3073505a16d52539a84843cf8c8369d4fd17167",
+      strip_prefix = "virtualenv-15.0.2",
+      build_file_content = "\n".join([
+          "py_binary(",
+          "    name = 'virtualenv',",
+          "    srcs = ['virtualenv.py'],",
+          "    data = glob(['**/*']),",
+          "    visibility = ['//visibility:public'],",
+          ")",
+      ])
   )

--- a/pex/wrapper/README
+++ b/pex/wrapper/README
@@ -1,0 +1,1 @@
+This readme file is just to make setuptools shut up.

--- a/pex/wrapper/setup.py
+++ b/pex/wrapper/setup.py
@@ -11,5 +11,7 @@ setuptools.setup(
     install_requires=[
         "pex",
         "wheel",
+        # Not strictly required, but requests makes SSL more likely to work
+        "requests",
     ],
 )

--- a/pex/wrapper/setup.py
+++ b/pex/wrapper/setup.py
@@ -8,6 +8,7 @@ setuptools.setup(
     author_email="bar",
     url="foo",
     py_modules=["pex_wrapper"],
+    version="0.1",
     install_requires=[
         "pex",
         "wheel",


### PR DESCRIPTION
This simplifies the pex bootstrapping process a fair bit by
letting virtualenv handle the tricky bits, and should more fully
isolate the bootstrapping steps from the host system's Python
site-packages.

Also:
- Update pex to 1.1.14
- Add the requests library to pex_wrapper.pex so pex can use it
- Add a fake version number to the fake setup.py so setuptools
  complains a little less