### PR TITLE
Set TEST_TMPDIR and PEX_ROOT for pytest

### DIFF
--- a/pex/testlauncher.sh.template
+++ b/pex/testlauncher.sh.template
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 RUNFILES="${TEST_SRCDIR:-${BASH_SOURCE[0]}.runfiles}"
-export HOME="${HOME:-${TEST_TMPDIR}}"
+export TEST_TMPDIR="${TEST_TMPDIR:-$(mktemp -d)}"
+export PEX_ROOT="${PEX_ROOT:-${TEST_TMPDIR}/.pex}"
 
 export PYTHONDONTWRITEBYTECODE=1
 


### PR DESCRIPTION
This ought to avoid pex writing to $HOME even when run without bazel
sandboxing.