### PR TITLE
Fall back to copying if hardlinking fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ os:
   - linux
   - osx
 
-matrix:
-  allow_failures:
-    - os: osx
-      env: BAZEL_VERSION=0.4.0
-
 # Only affects os=linux
 dist: trusty
 

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -232,7 +232,10 @@ def _pex_binary_impl(ctx):
       mnemonic = "LinkPex",
       inputs = [deploy_pex],
       outputs = [executable],
-      command = "ln -f %s %s" % (deploy_pex.path, executable.path),
+      command = "ln -f {pex} {exe} 2>/dev/null || cp -f {pex} {exe}".format(
+          pex = deploy_pex.path,
+          exe = executable.path,
+      ),
   )
 
   # TODO(benley): is there any reason to generate/include transitive runfiles?

--- a/pex/wrapper/pex_wrapper.py
+++ b/pex/wrapper/pex_wrapper.py
@@ -96,7 +96,12 @@ def main():
             try:
                 pex_builder.add_source(dereference_symlinks(src), dst)
             except OSError as err:
-                raise Exception("Failed to add %s: %s" % (src, err))
+                # Maybe we just can't use hardlinks? Try again.
+                if not pex_builder._copy:
+                    pex_builder._copy = True
+                    pex_builder.add_source(dereference_symlinks(src), dst)
+                else:
+                    raise Exception("Failed to add %s: %s" % (src, err))
 
         # Add resources from the manifest
         for dst, src in manifest.get('resources', {}).items():


### PR DESCRIPTION
This seems to be required for compatibility with sandboxing on Darwin.