### PR TITLE
add support for no-index, requirements files, and repo paths

### DIFF
--- a/pex/BUILD
+++ b/pex/BUILD
@@ -22,7 +22,7 @@ genrule(
         # Workaround really long shebang lines breaking on linux:
         # Use a /tmp path, but keep the actual venv inside the bazel outdir.
         # Avoids having to worry about cleanup, even if sandboxing is off.
-        TMPF=$$(mktemp)
+        TMPF=$$(mktemp 2>/dev/null || mktemp -t tmp)
         ln -sf "$$OUTDIR" "$$TMPF"
         VENV="$${TMPF}/venv"
 

--- a/pex/BUILD
+++ b/pex/BUILD
@@ -22,6 +22,7 @@ genrule(
         # Workaround really long shebang lines breaking on linux:
         # Use a /tmp path, but keep the actual venv inside the bazel outdir.
         # Avoids having to worry about cleanup, even if sandboxing is off.
+        # `mktemp -t tmp` is used for OS X.
         TMPF=$$(mktemp 2>/dev/null || mktemp -t tmp)
         ln -sf "$$OUTDIR" "$$TMPF"
         VENV="$${TMPF}/venv"

--- a/pex/BUILD
+++ b/pex/BUILD
@@ -22,7 +22,7 @@ genrule(
         # Workaround really long shebang lines breaking on linux:
         # Use a /tmp path, but keep the actual venv inside the bazel outdir.
         # Avoids having to worry about cleanup, even if sandboxing is off.
-        # `mktemp -t tmp` is used for OS X.
+        # `mktemp -t tmp` is used for older OS X versions.
         TMPF=$$(mktemp 2>/dev/null || mktemp -t tmp)
         ln -sf "$$OUTDIR" "$$TMPF"
         VENV="$${TMPF}/venv"


### PR DESCRIPTION
Needed to update the `pex_binary` rules to keep the clutter down in the BUILD files and make them easier to maintain. Figured I should open a PR in case you would like to pull this into master.