### PR TITLE
Better support of different python versions

### DIFF
--- a/pex/BUILD
+++ b/pex/BUILD
@@ -5,6 +5,7 @@ genrule(
     name = "pex_wrapper",
     srcs = [
         "wrapper/setup.py",
+        "wrapper/setup.cfg",
         "wrapper/pex_wrapper.py",
         "wrapper/README",
         "@setuptools_whl//file",

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -208,8 +208,6 @@ def _pex_binary_impl(ctx):
   # form the arguments to pex builder
   arguments =  [] if ctx.attr.zip_safe else ["--not-zip-safe"]
   arguments += [] if ctx.attr.pex_use_wheels else ["--no-use-wheel"]
-  if ctx.attr.interpreter:
-    arguments += ["--python", ctx.attr.interpreter]
   if ctx.attr.no_index:
     arguments += ["--no-index"]
   if ctx.attr.disable_cache:
@@ -250,6 +248,7 @@ def _pex_binary_impl(ctx):
           # Also, what if python is actually in /opt or something?
           'PATH': '/bin:/usr/bin:/usr/local/bin',
           'PEX_VERBOSE': str(ctx.attr.pex_verbosity),
+          'PEX_PYTHON': str(ctx.attr.interpreter),
           'PEX_ROOT': '.pex',  # So pex doesn't try to unpack into $HOME/.pex
       },
       arguments = arguments,

--- a/pex/wrapper/setup.cfg
+++ b/pex/wrapper/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
As described in issue #44, setting pex_binary's `interpreter` parameter to
python3 isn't enough, b/c the pex_wrapper will use the same python version that was used to
build pex_wrapper.pex, which is the same as the host machine
`/usr/bin/env python`. To fix this, we can use `PEX_PYTHON` environment variable,
which force pex to run pex_wrapper.pex to the specified version
pointed by that environment variable.