### PR TITLE
.travis.yml: Test release versions of Bazel: 0.7.0, 0.6.0, 0.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 
 env:
-  - BAZEL_URL=https://storage.googleapis.com/bazel/0.6.0/rc4/bazel-0.6.0rc4
+  - BAZEL_URL=https://storage.googleapis.com/bazel/0.7.0/release/bazel-0.7.0
+  - BAZEL_URL=https://storage.googleapis.com/bazel/0.6.1/release/bazel-0.6.1
   - BAZEL_URL=https://storage.googleapis.com/bazel/0.5.4/release/bazel-0.5.4
 
 os:


### PR DESCRIPTION
0.7.0 was released on 2017-10-18
0.6.0rc4 -> 0.6.1