### PR TITLE
Add support for native libraries

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -64,6 +64,13 @@ repo_file_types = FileType([
     ".tbz"
 ])
 
+extension_file_types = FileType([
+    ".so",   # Linux/Mac OS X
+    ".pyd",  # Windows
+    ".dll",  # BSD (Cygwin)
+    # ".o",    # Sun (disabled)
+])
+
 # As much as I think this test file naming convention is a good thing, it's
 # probably a bad idea to impose it as a policy to all OSS users of these rules,
 # so I guess let's skip it.
@@ -132,6 +139,7 @@ def _pex_library_impl(ctx):
   )
 
 
+
 def _gen_manifest(py, runfiles):
   """Generate a manifest for pex_wrapper.
 
@@ -156,10 +164,7 @@ def _gen_manifest(py, runfiles):
         ),
     )
 
-  # All .so files that end with .so, .so.#, .so.#.#, etc.
-  native_libs = [f.short_path for f in runfiles.files
-                 if f.extension == "so"
-                 or f.basename.partition(".so")[2].replace(".", "").isdigit()]
+  native_libs = extension_file_types.filter(runfiles.files)
   return struct(
       modules = pex_files,
       requirements = list(py.transitive_reqs),

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -156,10 +156,15 @@ def _gen_manifest(py, runfiles):
         ),
     )
 
+  # All .so files that end with .so, .so.#, .so.#.#, etc.
+  native_libs = [f.short_path for f in runfiles.files
+                 if f.extension == "so"
+                 or f.basename.partition(".so")[2].replace(".", "").isdigit()]
   return struct(
       modules = pex_files,
       requirements = list(py.transitive_reqs),
       prebuiltLibraries = [f.path for f in py.transitive_eggs],
+      nativeLibraries = native_libs,
   )
 
 

--- a/pex/wrapper/pex_wrapper.py
+++ b/pex/wrapper/pex_wrapper.py
@@ -109,7 +109,6 @@ def main():
             except Exception as err:
                 raise RuntimeError("Failed to add %s: %s" % (egg, err))
 
-        # TODO(mikekap): Do something about manifest['nativeLibraries'].
         with open(os.path.join(poptions.pex_root, 'native_libs.txt'), 'w') as libs_f:
             libs = manifest.get('nativeLibraries', [])
             libs_f.write('\n'.join(libs))

--- a/pex/wrapper/pex_wrapper.py
+++ b/pex/wrapper/pex_wrapper.py
@@ -45,6 +45,7 @@ def parse_manifest(manifest_text):
         "resources": [ {"src": "path_on_disk", "dest": "path_in_pex"}, ... ],
         "prebuiltLibraries": [ "path1", "path2", ... ],
         "requirements": [ "thing1", "thing2==version", ... ],
+        "nativeLibraries": ["path1.so", "path2.so"],
       }
     """
     return json.loads(manifest_text)
@@ -109,6 +110,10 @@ def main():
                 raise RuntimeError("Failed to add %s: %s" % (egg, err))
 
         # TODO(mikekap): Do something about manifest['nativeLibraries'].
+        with open(os.path.join(poptions.pex_root, 'native_libs.txt'), 'w') as libs_f:
+            libs = manifest.get('nativeLibraries', [])
+            libs_f.write('\n'.join(libs))
+        pex_builder.add_source(libs_f.name, 'native_libs.txt')
 
         pexbin.log('Saving PEX file to %s' % poptions.pex_name,
                    v=poptions.verbosity)


### PR DESCRIPTION
This generates a `native_libs.txt` file that includes all the `.so` files that are in the pex file, so they get extracted together (eager extraction).