### PR TITLE
pex_rules.bzl: Avoid spurious rebuild of virtualenv due to pyc

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -580,7 +580,8 @@ def pex_repositories():
           "py_binary(",
           "    name = 'virtualenv',",
           "    srcs = ['virtualenv.py'],",
-          "    data = glob(['**/*']),",
+          # exclude .pyc: Otherwise bazel detects a change after running virtualenv.py
+          "    data = glob(['**/*'], exclude=['*.pyc']),",
           "    visibility = ['//visibility:public'],",
           ")",
       ])


### PR DESCRIPTION
I noticed that when running anything that used the pex rules for the
second time, it would always rebuild pex_wrapper. The cause is that
when virtualenv is run, Python creates a .pyc file. The virtualenv
target uses a glob of "**/*", which detects a change. After that, it
will stay constant. To fix it: exclude .pyc files from the glob.

I suspect the Linux sandbox would not cause this error, but on Mac
the error can be reproduced as follows:

bazel clean --expunge
bazel build --subcommands //examples:foo
bazel build --subcommands --explain=explain.log //examples:foo

The second run will rebuild the target with the explaination:

Executing action 'Creating source manifest for
@virtualenv//:virtualenv [for host]': action command has changed.

Looking at the output of the command shows that the contents of
virtualenv.runfiles_manifest has added virtualenv.pyc.