### PR TITLE
Allow passing pex cache directory to speed up build

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -218,11 +218,12 @@ def _pex_binary_impl(ctx):
     arguments += ["--repo", repo]
   for egg in py.transitive_eggs:
     arguments += ["--find-links", egg.dirname]
+  if ctx.attr.cache_dir:
+     arguments += ["--cache-dir", ctx.attr.cache_dir]
   arguments += [
       "--pex-root", ".pex",  # May be redundant since we also set PEX_ROOT
       "--entry-point", main_pkg,
       "--output-file", deploy_pex.path,
-      "--cache-dir", ".pex/build",
       manifest_file.path,
   ]
 
@@ -327,7 +328,7 @@ pex_attrs = {
                             allow_files = repo_file_types),
     "data": attr.label_list(allow_files = True,
                             cfg = "data"),
-
+    "cache_dir": attr.string(),
     # Used by pex_binary and pex_*test, not pex_library:
     "_pexbuilder": attr.label(
         default = Label("//pex:pex_wrapper"),


### PR DESCRIPTION
When runing bazel build (or test) in standbox the pex cche (i.e. .pex/build)
ends up being created inside the sandbox directory which is deleted at the end
of bazel build (or test) which a second run will requires again to download
the same dependencies again and again.