### PR TITLE
Add a way to specify script attribute for pex

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -168,9 +168,15 @@ def _pex_binary_impl(ctx):
 
   if ctx.attr.entrypoint and ctx.file.main:
     fail("Please specify either entrypoint or main, not both.")
+  if ctx.attr.entrypoint and ctx.attr.script:
+    fail("Please specify either entrypoint or script, not both.")
+
   if ctx.attr.entrypoint:
     main_file = None
     main_pkg = ctx.attr.entrypoint
+  elif ctx.attr.script:
+    main_file = None
+    main_pkg = None
   elif ctx.file.main:
     main_file = ctx.file.main
   else:
@@ -218,9 +224,12 @@ def _pex_binary_impl(ctx):
     arguments += ["--repo", repo]
   for egg in py.transitive_eggs:
     arguments += ["--find-links", egg.dirname]
+  if ctx.attr.script:
+     arguments += ["--script", ctx.attr.script]
+  else:
+     arguments += ["--entry-point", main_pkg]
   arguments += [
       "--pex-root", ".pex",  # May be redundant since we also set PEX_ROOT
-      "--entry-point", main_pkg,
       "--output-file", deploy_pex.path,
       "--cache-dir", ".pex/build",
       manifest_file.path,
@@ -349,6 +358,7 @@ pex_bin_attrs = _dmerge(pex_attrs, {
     "main": attr.label(allow_files = True,
                        single_file = True),
     "entrypoint": attr.string(),
+    "script": attr.string(),
     "interpreter": attr.string(),
     "pex_use_wheels": attr.bool(default=True),
     "pex_verbosity": attr.int(default=0),
@@ -470,7 +480,7 @@ def pex_pytest(name, srcs, deps=[], eggs=[], data=[],
 
   Almost all of the attributes that can be used with pex_test work identically
   here, including those not specifically mentioned in this docstring.
-  Exceptions are `main` and `entrypoint`, which cannot be used with this macro.
+  Exceptions are `main` and `entrypoint` and `script`, which cannot be used with this macro.
 
   Args:
 
@@ -480,6 +490,8 @@ def pex_pytest(name, srcs, deps=[], eggs=[], data=[],
     fail("Specifying a `main` file makes no sense for pex_pytest.")
   if "entrypoint" in kwargs:
     fail("Do not specify `entrypoint` for pex_pytest.")
+  if "script" in kwargs:
+    fail("Do not specify `script` for pex_pytest.")
 
   pex_binary(
       name = "%s_runner" % name,


### PR DESCRIPTION
Sadly entrypoint isn't enough since not all scripts are tracked inside
python packages, e.g. ansible project have useful scripts like
ansible-playbook inside a folder called bin[1] that is not a python
package, hence we cannot use entrypoint for it.

[1] https://github.com/ansible/ansible/tree/devel/bin