### PR TITLE
pex_binary: Pass interpreter attribute as --python-shebang

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -19,3 +19,16 @@ pex_pytest(
     deps = [":libfoo"],
     size = "small",
 )
+
+# Tests that the interpreter attribute works
+pex_binary(
+    name = "foo_interpreter",
+    srcs = ["foo.py"],
+    interpreter = "/usr/bin/python2.7",
+)
+sh_test(
+    name = "interpreter_test",
+    srcs = ["interpreter_test.py"],
+    data = [":foo", ":foo_interpreter"],
+    args = ["$(location :foo)", "$(location :foo_interpreter)"],
+)

--- a/examples/interpreter_test.py
+++ b/examples/interpreter_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python2.7
+
+import subprocess
+import sys
+
+EXPECTED_OUTPUT = "I'm a pex file!\n"
+
+
+def test_pex(pex_path, expected_interpreter):
+    with open(pex_path) as f:
+        interpreter_line = f.readline()
+    if interpreter_line != expected_interpreter:
+        sys.stderr.write('ERROR %s: Unexpected interpreter: %s\n' % (
+            pex_path, repr(interpreter_line)))
+        sys.stderr.write('    Expected: %s\n' % (repr(expected_interpreter)))
+        sys.exit(1)
+
+    # check that it can be executed
+    output = subprocess.check_output(pex_path)
+    assert output == EXPECTED_OUTPUT
+
+
+def main():
+    '''Tests that the pex_binary interpreter attribute works.'''
+
+    if len(sys.argv) != 3:
+        sys.stderr.write('Error: Pass path to default PEX and changed PEX\n')
+        sys.exit(1)
+    default_pex = sys.argv[1]
+    changed_pex = sys.argv[2]
+
+    test_pex(default_pex, '#!/usr/bin/env python2.7\n')
+    test_pex(changed_pex, '#!/usr/bin/python2.7\n')
+    print 'PASS'
+
+
+if __name__ == '__main__':
+    main()

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -225,6 +225,8 @@ def _pex_binary_impl(ctx):
       "--cache-dir", ".pex/build",
       manifest_file.path,
   ]
+  if ctx.attr.interpreter != "":
+    arguments += ["--python-shebang", ctx.attr.interpreter]
 
   # form the inputs to pex builder
   _inputs = (


### PR DESCRIPTION
The pex_binary interpreter attribute is documented as "Path to the
python interpreter the pex should to use in its shebang line."
However, it was not being passed when building the PEX, so it did not
take effect.

It is getting passed as PEX_PYTHON, which changes the interpreter used
for *that invocation* of a given pex. This may have been a recent
change: https://github.com/pantsbuild/pex/issues/53

interpreter_test.py: Add a test that reads the files and verifies
    that the interpreter is set correctly.