### PR TITLE
pex_library: Support licenses attribute to allow rules in third_party

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -328,6 +328,10 @@ pex_attrs = {
     "data": attr.label_list(allow_files = True,
                             cfg = "data"),
 
+    # required for pex_library targets in third_party subdirs
+    # but theoretically a common attribute for all rules
+    "licenses": attr.license(),
+
     # Used by pex_binary and pex_*test, not pex_library:
     "_pexbuilder": attr.label(
         default = Label("//pex:pex_wrapper"),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,5 @@
+pex_pytest(
+    name = "third_party_test",
+    srcs = ["third_party_test.py"],
+    deps = ["//third_party/example:example"],
+)

--- a/tests/third_party_test.py
+++ b/tests/third_party_test.py
@@ -1,0 +1,6 @@
+import third_party.example.example
+import unittest
+
+class TestThirdParty(unittest.TestCase):
+    def test_example(self):
+        self.assertEqual('example', third_party.example.example.example())

--- a/third_party/example/BUILD
+++ b/third_party/example/BUILD
@@ -1,0 +1,8 @@
+# targets in third_party sub-directories must have license by default see:
+# https://github.com/bazelbuild/bazel/issues/188
+pex_library(
+    name = "example",
+    srcs = ["example.py"],
+    visibility = ["//visibility:public"],
+    licenses = ["notice"],  # makes bazel's default --check-licenses happy
+)

--- a/third_party/example/example.py
+++ b/third_party/example/example.py
@@ -1,0 +1,3 @@
+def example():
+    print 'example'
+    return 'example'


### PR DESCRIPTION
Bazel complains about rules in third_party subdirectories without a
licenses attribute. We should allow pex_library rules in this
location. Add the attribute to all pex rules, and add a test.

Fixes the following error:

```
ERROR: bazel_rules_pex/third_party/example/BUILD:1:1: third-party rule
'//third_party/example:example' lacks a license declaration with one
of the following types: notice, reciprocal, permissive, restricted,
unencumbered, by_exception_only
```